### PR TITLE
Return the device transport type

### DIFF
--- a/Sources/audio-devices/AudioDevices.swift
+++ b/Sources/audio-devices/AudioDevices.swift
@@ -15,6 +15,7 @@ struct AudioDevice: Hashable, Codable, Identifiable {
   let isInput: Bool
   let isOutput: Bool
   var volume: Double?
+  var transportType: String
 
   init(withId deviceId: AudioDeviceID) throws {
     id = deviceId
@@ -36,6 +37,50 @@ struct AudioDevice: Hashable, Codable, Identifiable {
     }
 
     uid = deviceUID as String
+
+    var deviceTransportType: UInt32 = 0
+    do {
+      try CoreAudioData.get(
+        id: deviceId,
+        selector: kAudioDevicePropertyTransportType,
+        value: &deviceTransportType
+      )
+    } catch {
+      deviceTransportType = 0
+    }
+
+    switch deviceTransportType {
+      case kAudioDeviceTransportTypeBluetooth,
+           kAudioDeviceTransportTypeBluetoothLE:
+        transportType = "bluetooth"
+
+      case kAudioDeviceTransportTypeBuiltIn:
+        transportType = "built-in"
+
+      case kAudioDeviceTransportTypeDisplayPort:
+        transportType = "displayport"
+
+      case kAudioDeviceTransportTypeFireWire:
+        transportType = "firewire"
+
+      case kAudioDeviceTransportTypeHDMI:
+        transportType = "hdmi"
+
+      case kAudioDeviceTransportTypePCI:
+        transportType = "pci"
+
+      case kAudioDeviceTransportTypeThunderbolt:
+        transportType = "thunderbolt"
+
+      case kAudioDeviceTransportTypeUSB:
+        transportType = "usb"
+
+      case kAudioDeviceTransportTypeVirtual:
+        transportType = "virtual"
+
+      default:
+        transportType = "unknown"
+    }
 
     let inputChannels: UInt32 = try CoreAudioData.size(
       id: deviceId,

--- a/Sources/audio-devices/AudioDevices.swift
+++ b/Sources/audio-devices/AudioDevices.swift
@@ -9,13 +9,31 @@ struct AudioDevice: Hashable, Codable, Identifiable {
     case invalidVolumeValue
   }
 
+  enum TransportType: String, Codable {
+    case avb,
+         aggregate,
+         airplay,
+         autoaggregate,
+         bluetooth,
+         bluetoothle,
+         builtin,
+         displayport,
+         firewire,
+         hdmi,
+         pci,
+         thunderbolt,
+         usb,
+         virtual,
+         unknown
+  }
+
   let id: AudioDeviceID
   let name: String
   let uid: String
   let isInput: Bool
   let isOutput: Bool
   var volume: Double?
-  var transportType: String
+  var transportType: TransportType
 
   init(withId deviceId: AudioDeviceID) throws {
     id = deviceId
@@ -50,36 +68,21 @@ struct AudioDevice: Hashable, Codable, Identifiable {
     }
 
     switch deviceTransportType {
-      case kAudioDeviceTransportTypeBluetooth,
-           kAudioDeviceTransportTypeBluetoothLE:
-        transportType = "bluetooth"
-
-      case kAudioDeviceTransportTypeBuiltIn:
-        transportType = "built-in"
-
-      case kAudioDeviceTransportTypeDisplayPort:
-        transportType = "displayport"
-
-      case kAudioDeviceTransportTypeFireWire:
-        transportType = "firewire"
-
-      case kAudioDeviceTransportTypeHDMI:
-        transportType = "hdmi"
-
-      case kAudioDeviceTransportTypePCI:
-        transportType = "pci"
-
-      case kAudioDeviceTransportTypeThunderbolt:
-        transportType = "thunderbolt"
-
-      case kAudioDeviceTransportTypeUSB:
-        transportType = "usb"
-
-      case kAudioDeviceTransportTypeVirtual:
-        transportType = "virtual"
-
-      default:
-        transportType = "unknown"
+      case kAudioDeviceTransportTypeAVB:           transportType = TransportType.avb
+      case kAudioDeviceTransportTypeAggregate:     transportType = TransportType.aggregate
+      case kAudioDeviceTransportTypeAirPlay:       transportType = TransportType.airplay
+      case kAudioDeviceTransportTypeAutoAggregate: transportType = TransportType.autoaggregate
+      case kAudioDeviceTransportTypeBluetooth:     transportType = TransportType.bluetooth
+      case kAudioDeviceTransportTypeBluetoothLE:   transportType = TransportType.bluetoothle
+      case kAudioDeviceTransportTypeBuiltIn:       transportType = TransportType.builtin
+      case kAudioDeviceTransportTypeDisplayPort:   transportType = TransportType.displayport
+      case kAudioDeviceTransportTypeFireWire:      transportType = TransportType.firewire
+      case kAudioDeviceTransportTypeHDMI:          transportType = TransportType.hdmi
+      case kAudioDeviceTransportTypePCI:           transportType = TransportType.pci
+      case kAudioDeviceTransportTypeThunderbolt:   transportType = TransportType.thunderbolt
+      case kAudioDeviceTransportTypeUSB:           transportType = TransportType.usb
+      case kAudioDeviceTransportTypeVirtual:       transportType = TransportType.virtual
+      default:                                     transportType = TransportType.unknown
     }
 
     let inputChannels: UInt32 = try CoreAudioData.size(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,15 +2128,6 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-macos-accessibility-permissions@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/macos-accessibility-permissions/-/macos-accessibility-permissions-1.0.1.tgz#b3f50edeaad621cd55348ad6137375f321c53e19"
-  integrity sha512-aajZqDpK3ahBT0bIzH91cl/qp/HPRwG0ECztsu0Uo85VeUw3O4va1vIZzmt7Aw+icTzeadogo0TGZkpWAr6DOQ==
-  dependencies:
-    electron-util "^0.13.1"
-    execa "^4.0.0"
-    macos-version "^5.2.0"
-
 macos-version@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/macos-version/-/macos-version-5.2.0.tgz#ae3a25155877902bbc5f5ae6b2d57b1ddce2e79e"
@@ -2475,11 +2466,6 @@ p-cancelable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
   integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
-
-p-cancelable@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.0.0.tgz#4a3740f5bdaf5ed5d7c3e34882c6fb5d6b266a6e"
-  integrity sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==
 
 p-finally@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This adds the device "transport type" to the output, which allows you to determine if a device is built-in, USB, bluetooth, or a host of other types.

This can be important in knowing whether to accept input or output from that particular device, or display a warning about bluetooth audio quality when using both input and output from the same device.