### PR TITLE
feat: implement getDeviceByUID method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,5 @@ public/
 # DynamoDB Local files
 .dynamodb/
 
-# End of https://www.gitignore.io/api/node
+# End of https://www.gitignore.io/api/node.vscode
+.vscode

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,7 +91,7 @@ export const getDevice: {
   const device = await getDevice(73);
   ```
   */
-  (): Promise<Device>;
+  (deviceId: number): Promise<Device>;
 
   /**
   Get an audio device by ID.
@@ -103,7 +103,33 @@ export const getDevice: {
   const device = getDevice.sync(73);
   ```
   */
-  sync: () => Device;
+  sync: (deviceId: number) => Device;
+};
+
+export const getDeviceByUID: {
+  /**
+  Get an audio device by UID.
+
+  @returns A promise that resolves with the device.
+
+  @example
+  ```
+  const device = await getDeviceByUID("BGMDevice");
+  ```
+  */
+  (deviceUID: string): Promise<Device>;
+
+  /**
+  Get an audio device by ID.
+
+  @returns The device.
+
+  @example
+  ```
+  const device = getDevice.sync(73);
+  ```
+  */
+  sync: (deviceId: number) => Device;
 };
 
 export const getOutputDevices: {

--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ generateExport('getOutputDevices', () => ['list', '--output', '--json'], parseSt
 
 generateExport('getDevice', deviceId => ['get', '--json', deviceId], parseStdout);
 
+generateExport('getDeviceByUID', deviceUID => ['getDeviceByUID', '--json', deviceUID], parseStdout);
+
 generateExport('getDefaultOutputDevice', () => ['output', 'get', '--json'], parseStdout);
 
 generateExport('getDefaultInputDevice', () => ['input', 'get', '--json'], parseStdout);


### PR DESCRIPTION
Hi,

This PR includes a new method getDeviceByUID which does exactly that ^^ get a device using its UID instead of id, it can be useful as the UID is known ahead of creation of the device, as well that the only way to find an hidden device (as explained here https://gist.github.com/kdepp/46c812b05cda6e44a292328b31d0784c#file-audiohardwarebase-h-L696-L700).
That's my first time I'm writing some Swift so it works but it is probably not optimal, feedbacks really welcome.

Thanks for your time