### PR TITLE
feat: add isHidden property and allow to set isHidden device property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,4 @@ public/
 # DynamoDB Local files
 .dynamodb/
 
-# End of https://www.gitignore.io/api/node
+# End of https://www.gitignore.io/api/node.vscode

--- a/Sources/audio-devices/AudioDevices.swift
+++ b/Sources/audio-devices/AudioDevices.swift
@@ -12,6 +12,7 @@ struct AudioDevice: Hashable, Codable, Identifiable {
   let id: AudioDeviceID
   let name: String
   let uid: String
+  let isHidden: Bool
   let isInput: Bool
   let isOutput: Bool
   var transportType: TransportType
@@ -21,16 +22,19 @@ struct AudioDevice: Hashable, Codable, Identifiable {
 
     var deviceName = "" as CFString
     var deviceUID = "" as CFString
+    var isHidden: UInt32 = 0
 
     do {
       try CoreAudioData.get(id: deviceId, selector: kAudioObjectPropertyName, value: &deviceName)
       try CoreAudioData.get(id: deviceId, selector: kAudioDevicePropertyDeviceUID, value: &deviceUID)
+      try CoreAudioData.get(id: deviceId, selector: kAudioDevicePropertyIsHidden, value: &isHidden)
     } catch {
       throw Error.invalidDeviceId
     }
 
     self.name = deviceName as String
     self.uid = deviceUID as String
+    self.isHidden = isHidden == 1 ? true : false
 
     var deviceTransportType: UInt32 = 0
     do {
@@ -248,6 +252,18 @@ extension AudioDevice {
     try CoreAudioData.set(
       selector: deviceType.selector,
       value: &deviceId
+    )
+  }
+
+  static func setIsHidden(device: Self, isHidden: Bool) throws {
+
+    var deviceId = device.id
+
+    var value: UInt32 = UInt32(isHidden ? 1 : 0)
+    try CoreAudioData.set(
+      id: deviceId,
+      selector: kAudioDevicePropertyIsHidden,
+      value: &value
     )
   }
 

--- a/Sources/audio-devices/main.swift
+++ b/Sources/audio-devices/main.swift
@@ -142,6 +142,27 @@ final class SetOutputCommand: Command {
   }
 }
 
+final class SetIsHiddenCommand: Command {
+  let name = "setIsHiddenDeviceProperty"
+
+  @Param var deviceId: Int
+  @Param var isHidden: Bool
+
+  func execute() throws {
+    let device = try getDevice(deviceId: deviceId)
+    print("device id found while setIsHiddenCommand \(deviceId)")
+
+    do {
+      try AudioDevice.setIsHidden(device: device, isHidden: isHidden)
+      print("Set is hidden device property was set to \(device.name)")
+    } catch AudioDevice.Error.invalidDevice {
+      print("\(device.name) is not an output device", to: .standardError)
+    } catch {
+      throw error
+    }
+  }
+}
+
 final class InputGroup: CommandGroup {
   let shortDescription = "Get or set the default input device"
   let name = "input"
@@ -342,6 +363,7 @@ let audioDevices = CLI(name: "audio-devices")
 audioDevices.commands = [
   ListCommand(),
   GetCommand(),
+  SetIsHiddenCommand(),
   OutputGroup(),
   InputGroup(),
   SystemGroup(),

--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ generateExport('getDefaultInputDevice', () => ['input', 'get', '--json'], parseS
 
 generateExport('getDefaultSystemDevice', () => ['system', 'get', '--json'], parseStdout);
 
+generateExport('setIsHiddenDeviceProperty', (deviceId, isHidden) => ['output', 'set', deviceId, isHidden], throwIfStderr);
+
 generateExport('setDefaultOutputDevice', deviceId => ['output', 'set', deviceId], throwIfStderr);
 
 generateExport('setDefaultInputDevice', deviceId => ['input', 'set', deviceId], throwIfStderr);


### PR DESCRIPTION
Hi,

The changes introduced allow to see if a device is hidden from the main list of audio devices, as well as hidding a specific device in theory.
I'm having trouble to make it work properly, I'm getting this error:

```
❯ ./audio-devices setIsHiddenDeviceProperty 106 true
device id found while setIsHiddenCommand 106
Error: The operation couldn’t be completed. (OSStatus error 1852797029.)
```

The OSStatus error leads to this error `kAudioHardwareIllegalOperationError`  (https://www.osstatus.com/search/results?platform=all&framework=all&search=1852797029).
<img width="1243" alt="image" src="https://user-images.githubusercontent.com/360101/212732250-8ddc57c7-5eef-49df-9968-cc86fcfe6fc9.png">

I'm sure I'm doing something wrong here, but I cannot figure out what is it. Do you have an idea ?
Thanks for your help
