### PR TITLE
Fix compile warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 
 # Created by https://www.gitignore.io/api/node
 # Edit at https://www.gitignore.io/?templates=node
@@ -87,7 +88,7 @@ typings/
 # nuxt.js build output
 .nuxt
 
-# react / gatsby 
+# react / gatsby
 public/
 
 # vuepress build output

--- a/Sources/audio-devices/main.swift
+++ b/Sources/audio-devices/main.swift
@@ -265,7 +265,7 @@ final class SetVolumeCommand: Command {
   @Param var volume: Double
 
   func execute() throws {
-    var device = try getDevice(deviceId: deviceId)
+    let device = try getDevice(deviceId: deviceId)
 
     do {
       try device.setVolume(volume)


### PR DESCRIPTION
Fixes this compilation warning:

```
/Users/user/macos-audio-devices/Sources/audio-devices/main.swift:268:9: warning: variable 'device' was never mutated; consider changing to 'let' constant
    var device = try getDevice(deviceId: deviceId)
    ~~~ ^
    let
```

Also adds `.DS_Store` to `.gitignore`.
