### PR TITLE
Upgrade electron-util to 0.17.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "electron-util": "^0.13.1",
+    "electron-util": "^0.17.2",
     "execa": "^4.0.0",
     "macos-version": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,10 +705,10 @@ electron-is-dev@^1.1.0:
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-1.1.0.tgz#b15a2a600bdc48a51a857d460e05f15b19a2522c"
   integrity sha512-Z1qA/1oHNowGtSBIcWk0pcLEqYT/j+13xUw/MYOrBUOL4X7VN0i0KCTf5SqyvMPmW5pSPKbo28wkxMxzZ20YnQ==
 
-electron-util@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/electron-util/-/electron-util-0.13.1.tgz#ba3b9cb7e5fdb6a51970a01e9070877cf7855ef8"
-  integrity sha512-CvOuAyQPaPtnDp7SspwnT1yTb1yynw6yp4LrZCfEJ7TG/kJFiZW9RqMHlCEFWMn3QNoMkNhGVeCvWJV5NsYyuQ==
+electron-util@^0.17.2:
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/electron-util/-/electron-util-0.17.2.tgz#6b0fe798ae0154585e7e0e96a707bfeae592be05"
+  integrity sha512-4Kg/aZxJ2BZklgyfH86px/D2GyROPyIcnAZar+7KiNmKI2I5l09pwQTP7V95zM3FVhgDQwV9iuJta5dyEvuWAw==
   dependencies:
     electron-is-dev "^1.1.0"
     new-github-issue-url "^0.2.1"


### PR DESCRIPTION
Hello,

I tried to use `yarn link` to use my local build of this package but yarn complained that the `electron-util` version was mismatched with the one that I was sourcing from my own `package.json` file. So I had to bump it.

For some reason it doesn't complain when I use the npm version of this package. I don't really know why.

It seems like `fixPathForAsarUnpack` hasn't changed in the latest version so I think the upgrade should just work.
